### PR TITLE
removed blank lines from sol.dark and sol.light to avoid error messages when sourcing in mintty

### DIFF
--- a/sol.dark
+++ b/sol.dark
@@ -1,8 +1,6 @@
 echo -ne   '\eP\e]10;#839496\a'  # Foreground   -> base0
 echo -ne   '\eP\e]11;#002B36\a'  # Background   -> base03
-
 echo -ne   '\eP\e]12;#DC322F\a'  # Cursor       -> red
-
 echo -ne  '\eP\e]4;0;#073642\a'  # black        -> Base02
 echo -ne  '\eP\e]4;8;#002B36\a'  # bold black   -> Base03
 echo -ne  '\eP\e]4;1;#DC322F\a'  # red          -> red

--- a/sol.light
+++ b/sol.light
@@ -1,8 +1,6 @@
 echo -ne   '\eP\e]10;#657B83\a'  # Foreground   -> base00
 echo -ne   '\eP\e]11;#FDF6E3\a'  # Background   -> base3
-
 echo -ne   '\eP\e]12;#DC322F\a'  # Cursor       -> red
-
 echo -ne  '\eP\e]4;0;#073642\a'  # black        -> Base02
 echo -ne  '\eP\e]4;8;#002B36\a'  # bold black   -> Base03
 echo -ne  '\eP\e]4;1;#DC322F\a'  # red          -> red


### PR DESCRIPTION
TvE@TvE-PC-WORK /cygdrive/c/Users/TvE/SourceCache/mintty-colors-solarized
$ source sol.light
-bash: $'\r': command not found
-bash: $'\r': command not found
